### PR TITLE
Populate extlinux.conf with GigRouter DTB file.

### DIFF
--- a/meta-gigrouter/conf/machine/gigrouter.conf
+++ b/meta-gigrouter/conf/machine/gigrouter.conf
@@ -27,6 +27,14 @@ TEGRA_FLASHVAR_WB0SDRAM_BCT = "tegra234-p3701-0008-wb0sdram-l4t.dts"
 PREFERRED_PROVIDER_virtual/dtb = "gigrouter-devicetree"
 DTBFILE:gigrouter = "tegra234-gigrouter-p3737-0000+p3701-0008.dtb"
 
+# Populates the /boot directory with the requisite DTB file
+IMAGE_BOOT_FILES += " ${DTBFILE}"
+
+# Add an entry to the /boot/extlinux/extlinux.conf file naming the
+# specific DTB file. This passes the DTB to the kernel at startup
+UBOOT_EXTLINUX = "1"
+UBOOT_EXTLINUX_FDT = "${DTBFILE}"
+
 MACHINE_EXTRA_RRECOMMENDS:append = " kernel-modules"
 
 require conf/machine/include/agx-orin.inc

--- a/meta-gigrouter/recipes-kernel/gigrouter-devicetree/gigrouter-devicetree_1.0.0.bb
+++ b/meta-gigrouter/recipes-kernel/gigrouter-devicetree/gigrouter-devicetree_1.0.0.bb
@@ -38,6 +38,10 @@ do_deploy() {
     install -m 0644 ${WORKDIR}/tegra234-gigrouter-p3737-0000+p3701-0004.dtb ${DEPLOYDIR}/devicetree/
     install -m 0644 ${WORKDIR}/tegra234-gigrouter-p3737-0000+p3701-0005.dtb ${DEPLOYDIR}/devicetree/
     install -m 0644 ${WORKDIR}/tegra234-gigrouter-p3737-0000+p3701-0008.dtb ${DEPLOYDIR}/devicetree/
+
+    # Add GigRouter DTB to deployment directory. The uefi recipe which populates /boot
+    # and extlinux.conf through l4t-launcher-extlinux.bb will search in this location.
+    install -m 0644 ${WORKDIR}/tegra234-gigrouter-p3737-0000+p3701-0008.dtb ${DEPLOYDIR}/
 }
 
 addtask deploy before do_build after do_install


### PR DESCRIPTION
This changeset ensures the GigRouter DTB file is copied to the /boot directory and is listed in extlinux.conf. This allows the bootloader to pass the DTB as an argument to the kernel prior to startup.