### PR TITLE
Optionally enable secondary serial as interactive console

### DIFF
--- a/kas/gig-base-kas-config.yml
+++ b/kas/gig-base-kas-config.yml
@@ -64,3 +64,4 @@ local_conf_header:
     IMAGE_BUILDINFO_VARS:append = "TUNE_FEATURES TARGET_FPU"
     PACKAGE_CLASSES += "package_deb"
     EXTRA_IMAGE_FEATURES ?= "allow-empty-password empty-root-password allow-root-login package-management"
+    INSTALL_IMAGE:append = " cw-interactive-serial"

--- a/meta-gig/recipes-support/cw-interactive-serial/cw-interactive-serial_1.0.0.bb
+++ b/meta-gig/recipes-support/cw-interactive-serial/cw-interactive-serial_1.0.0.bb
@@ -1,0 +1,33 @@
+SUMMARY = "Provide an interactive console on the secondary serial device."
+DESCRIPTION = "When a touch file is present will start an interactive console on the secondary serial device."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+SECTION = "Custom"
+PR = "r0"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = " \
+    file://condition.conf \
+"
+
+TOUCH_FILE = "/etc/cw-interactive-ttyTHS1"
+
+inherit allarch
+
+do_install() {
+    install -d ${D}${sysconfdir}/systemd/system/getty.target.wants
+    install -d ${D}${sysconfdir}/systemd/system/serial-getty@ttyTHS1.service.d
+
+    # Use the existing serial-getty system file with an argument for ttyTHS1
+    ln -sf ${libdir}/systemd/system/serial-getty@.service \
+        ${D}${sysconfdir}/systemd/system/getty.target.wants/serial-getty@ttyTHS1.service
+
+    # Inhibit starting the service unless a touch file has been added
+    # so that the support is optional to the end user
+    if [ -f "${WORKDIR}/condition.conf" ]; then
+        sed "s|@TOUCH_FILE@|${TOUCH_FILE}|g" ${WORKDIR}/condition.conf \
+            > ${D}${sysconfdir}/systemd/system/serial-getty@ttyTHS1.service.d/condition.conf
+    fi
+}
+
+FILES:${PN} += "${sysconfdir}/systemd/system/"

--- a/meta-gig/recipes-support/cw-interactive-serial/files/condition.conf
+++ b/meta-gig/recipes-support/cw-interactive-serial/files/condition.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=@TOUCH_FILE@


### PR DESCRIPTION
This changeset allows ttyTHS1 to be used as an interactive console. Since this use-case is required by some users, but not others who use the port for data, it's gated by the use of a touch file. When /etc/cw-interactive-ttyTHS1 is present the console features will be enabled.