### PR TITLE
Use update-alternatives to link cuda paths

### DIFF
--- a/meta-gig/recipes-devtools/cuda/cuda-nvcc_12.6.68-1.bbappend
+++ b/meta-gig/recipes-devtools/cuda/cuda-nvcc_12.6.68-1.bbappend
@@ -1,6 +1,0 @@
-inherit update-alternatives
-
-ALTERNATIVE:${PN} = "cuda"
-ALTERNATIVE_LINK_NAME[cuda] = "${prefix}/local/cuda"
-ALTERNATIVE_TARGET[cuda] = "${prefix}/local/cuda-12.6"
-ALTERNATIVE_PRIORITY[cuda] = "114"


### PR DESCRIPTION
This changeset uses update-alternatives to establish a managed symlink between /usr/local/cuda and /usr/local/cuda-12.6. This is required as cuda projects often assume the presence of this link so references to explicit versions of cuda don't need to be maintained in application code.