### PR TITLE
Support nvidia's runtime container

### DIFF
--- a/meta-gig/recipes-containers/nvidia-docker/files/daemon.json
+++ b/meta-gig/recipes-containers/nvidia-docker/files/daemon.json
@@ -1,0 +1,9 @@
+{
+    "runtimes": {
+        "nvidia": {
+            "path": "nvidia-container-runtime",
+            "runtimeArgs": []
+        }
+    },
+    "default-runtime": "nvidia"
+}

--- a/meta-gig/recipes-containers/nvidia-docker/nvidia-docker_%.bbappend
+++ b/meta-gig/recipes-containers/nvidia-docker/nvidia-docker_%.bbappend
@@ -1,0 +1,18 @@
+SUMMARY = "Support GPU access from docker containers"
+DESCRIPTION = "Provides a JSON configuration for allowing nvidia runtime container access to GPU hardware from Docker containers"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+SECTION = "Custom"
+PR = "r0"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = " \
+    file://daemon.json \
+"
+
+do_install() {
+    install -d ${D}${sysconfdir}/docker
+    install -m 0755 ${WORKDIR}/daemon.json ${D}${sysconfdir}/docker/daemon.json
+}
+
+FILES:${PN} += "${sbindir}/daemon.json"

--- a/meta-gig/recipes-core/images/cambrian-image.bb
+++ b/meta-gig/recipes-core/images/cambrian-image.bb
@@ -4,6 +4,7 @@ SUMMARY = "Custom image for Cambrian Works Gig family of products"
 DESCRIPTION = "${SUMMARY}"
 
 DISTRO = "cambrian-distro"
+DISTRO_FEATURES:append = " virtualization"
 
 # Cambrian Works packages
 IMAGE_INSTALL:append = " cw-drive-setup"
@@ -140,6 +141,8 @@ IMAGE_INSTALL:append = " libnvidia-container"
 IMAGE_INSTALL:append = " libnvjitlink"
 IMAGE_INSTALL:append = " libnvjpeg"
 IMAGE_INSTALL:append = " nv-tegra-release"
+IMAGE_INSTALL:append = " nvidia-docker"
+IMAGE_INSTALL:append = " nvidia-container-toolkit"
 IMAGE_INSTALL:append = " tegra-cuda-utils"
 IMAGE_INSTALL:append = " tegra-nvpmodel"
 IMAGE_INSTALL:append = " tegra-nvpmodel-base"


### PR DESCRIPTION
This changeset adds requisite packages and configuration for nvidia's runtime container. This allows access to the GPU acceleration from a Docker container.