### PR TITLE
Include cw-interactive-serial in output image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,6 @@ The format is based on [Keep a changelog](https://keepachangelog.com/en/1.0.0/).
 - **[nvidia-kernel-oot]** - Update device tree patch file for R36.5 which enables Message-Signal-Interrupt (MSI) handling of PCIe interface interrupts. Result is the external 10G Ethernet interfaces can run at full speed.
 - **[cambrian-image]** - Remove packages deprecated by R36.5 and add new packages related to tensor and CUDA.
 - **[README]** - Update README links to external R36.5 documentation.
+
+### Fixed
+- **[cw-interactive-serial]**- cw-interactive-serial wasn't being included in final build image without manual rebuilding. Resolved by fixing incorrect variable naming and having the recipe inherit from systemd package.

--- a/kas/gig-base-kas-config.yml
+++ b/kas/gig-base-kas-config.yml
@@ -64,4 +64,3 @@ local_conf_header:
     IMAGE_BUILDINFO_VARS:append = "TUNE_FEATURES TARGET_FPU"
     PACKAGE_CLASSES += "package_deb"
     EXTRA_IMAGE_FEATURES ?= "allow-empty-password empty-root-password allow-root-login package-management"
-    INSTALL_IMAGE:append = " cw-interactive-serial"

--- a/meta-gig/recipes-core/images/cambrian-image.bb
+++ b/meta-gig/recipes-core/images/cambrian-image.bb
@@ -8,6 +8,7 @@ DISTRO_FEATURES:append = " virtualization"
 
 # Cambrian Works packages
 IMAGE_INSTALL:append = " cw-drive-setup"
+IMAGE_INSTALL:append = " cw-interactive-serial"
 
 # Base image appends
 IMAGE_INSTALL:append = " android-tools-fstools"

--- a/meta-gig/recipes-support/cw-interactive-serial/cw-interactive-serial_1.0.0.bb
+++ b/meta-gig/recipes-support/cw-interactive-serial/cw-interactive-serial_1.0.0.bb
@@ -12,22 +12,25 @@ SRC_URI = " \
 
 TOUCH_FILE = "/etc/cw-interactive-ttyTHS1"
 
+inherit systemd
 inherit allarch
 
+RDEPENDS:{PN} += "systemd"
+
 do_install() {
-    install -d ${D}${sysconfdir}/systemd/system/getty.target.wants
-    install -d ${D}${sysconfdir}/systemd/system/serial-getty@ttyTHS1.service.d
+    install -d ${D}${systemd_system_unitdir}/getty.target.wants
+    install -d ${D}${systemd_system_unitdir}/serial-getty@ttyTHS1.service.d
 
     # Use the existing serial-getty system file with an argument for ttyTHS1
     ln -sf ${libdir}/systemd/system/serial-getty@.service \
-        ${D}${sysconfdir}/systemd/system/getty.target.wants/serial-getty@ttyTHS1.service
+        ${D}${systemd_system_unitdir}/getty.target.wants/serial-getty@ttyTHS1.service
 
     # Inhibit starting the service unless a touch file has been added
     # so that the support is optional to the end user
     if [ -f "${WORKDIR}/condition.conf" ]; then
         sed "s|@TOUCH_FILE@|${TOUCH_FILE}|g" ${WORKDIR}/condition.conf \
-            > ${D}${sysconfdir}/systemd/system/serial-getty@ttyTHS1.service.d/condition.conf
+            > ${D}${systemd_system_unitdir}/serial-getty@ttyTHS1.service.d/condition.conf
     fi
 }
 
-FILES:${PN} += "${sysconfdir}/systemd/system/"
+FILES:${PN} += "${systemd_system_unitdir}"


### PR DESCRIPTION
This changeset resolves a bug where cw-interactive-serial, required to enable the secondary serial port (ttyTHS1) as an interactive console, wasn't being included in build output. Resolution was renaming an incorrect variable name and inheriting the recipe from the systemd package for directory consistency.