### PR TITLE
Support initrd-flash

### DIFF
--- a/meta-gig/recipes-kernel/nvidia-kernel-oot/files/0002-USB-peripheral-mode-devicetree.patch
+++ b/meta-gig/recipes-kernel/nvidia-kernel-oot/files/0002-USB-peripheral-mode-devicetree.patch
@@ -1,0 +1,223 @@
+--- a/hardware/nvidia/t23x/nv-public/tegra234-p3737-0000+p3701.dtsi
++++ b/hardware/nvidia/t23x/nv-public/tegra234-p3737-0000+p3701.dtsi
+@@ -114,7 +114,7 @@
+ 			status = "okay";
+ 		};
+ 
+-		padctl@3520000 {
++		xusb_padctl: padctl@3520000 {
+ 			status = "okay";
+ 
+ 			pads {
+@@ -125,15 +125,15 @@
+ 						};
+ 
+ 						usb2-1 {
+-							status = "okay";
++							status = "disabled";
+ 						};
+ 
+ 						usb2-2 {
+-							status = "okay";
++							status = "disabled";
+ 						};
+ 
+ 						usb2-3 {
+-							status = "okay";
++							status = "disabled";
+ 						};
+ 					};
+ 				};
+@@ -141,15 +141,15 @@
+ 				usb3 {
+ 					lanes {
+ 						usb3-0 {
+-							status = "okay";
++							status = "disabled";
+ 						};
+ 
+ 						usb3-1 {
+-							status = "okay";
++							status = "disabled";
+ 						};
+ 
+ 						usb3-2 {
+-							status = "okay";
++							status = "disabled";
+ 						};
+ 					};
+ 				};
+@@ -157,73 +157,60 @@
+ 
+ 			ports {
+ 				usb2-0 {
+-					mode = "otg";
++					mode = "peripheral";
+ 					usb-role-switch;
++					role-switch-default-mode = "peripheral";
+ 					status = "okay";
+-
+-					port {
+-						hs_typec_p1: endpoint {
+-							remote-endpoint = <&hs_ucsi_ccg_p1>;
+-						};
+-					};
+ 				};
+ 
+ 				usb2-1 {
+ 					mode = "host";
+-					status = "okay";
+-
+-					port {
+-						hs_typec_p0: endpoint {
+-							remote-endpoint = <&hs_ucsi_ccg_p0>;
+-						};
+-					};
++					status = "disabled";
+ 				};
+ 
+ 				usb2-2 {
+ 					mode = "host";
+-					status = "okay";
++					status = "disabled";
+ 				};
+ 
+ 				usb2-3 {
+ 					mode = "host";
+-					status = "okay";
++					status = "disabled";
+ 				};
+ 
+ 				usb3-0 {
+ 					nvidia,usb2-companion = <1>;
+-					status = "okay";
+-
+-					port {
+-						ss_typec_p0: endpoint {
+-							remote-endpoint = <&ss_ucsi_ccg_p0>;
+-						};
+-					};
++					status = "disabled";
+ 				};
+ 
+ 				usb3-1 {
+ 					nvidia,usb2-companion = <0>;
+-					status = "okay";
+-
+-					port {
+-						ss_typec_p1: endpoint {
+-							remote-endpoint = <&ss_ucsi_ccg_p1>;
+-						};
+-					};
++					status = "disabled";
+ 				};
+ 
+ 				usb3-2 {
+ 					nvidia,usb2-companion = <3>;
+-					status = "okay";
++					status = "disabled";
+ 				};
+ 			};
+ 		};
+ 
++		enable_vbus: regulator-fake-vbus {
++			compatible = "regulator-fixed";
++			regulator-name = "enable-vbus";
++			regulator-min-microvolt = <5000000>;
++			regulator-max-microvolt = <5000000>;
++			regulator-always-on;
++			regulator-boot-on;
++		};
++
+ 		usb@3550000 {
+ 			status = "okay";
+ 
+-			phys = <&{/bus@0/padctl@3520000/pads/usb2/lanes/usb2-0}>,
+-			       <&{/bus@0/padctl@3520000/pads/usb3/lanes/usb3-1}>;
+-			phy-names = "usb2-0", "usb3-0";
++			phys = <&{/bus@0/padctl@3520000/pads/usb2/lanes/usb2-0}>;
++			phy-names = "usb2-0";
++			nvidia,xusb-padctl = <&xusb_padctl>;
++			vbus-supply = <&enable_vbus>;
+ 		};
+ 
+ 		usb@3610000 {
+@@ -258,78 +245,6 @@
+ 				};
+ 			};
+ 		};
+-
+-		i2c@c240000 {
+-			status = "okay";
+-
+-			typec@8 {
+-				compatible = "cypress,cypd4226";
+-				reg = <0x08>;
+-				interrupt-parent = <&gpio>;
+-				interrupts = <TEGRA234_MAIN_GPIO(Y, 4) IRQ_TYPE_LEVEL_LOW>;
+-				firmware-name = "nvidia,jetson-agx-xavier";
+-				status = "okay";
+-
+-				#address-cells = <1>;
+-				#size-cells = <0>;
+-
+-				ccg_typec_con0: connector@0 {
+-					compatible = "usb-c-connector";
+-					reg = <0>;
+-					label = "USB-C";
+-					data-role = "host";
+-
+-					ports {
+-						#address-cells = <1>;
+-						#size-cells = <0>;
+-
+-						port@0 {
+-							reg = <0>;
+-
+-							hs_ucsi_ccg_p0: endpoint {
+-								remote-endpoint = <&hs_typec_p0>;
+-							};
+-						};
+-
+-						port@1 {
+-							reg = <1>;
+-
+-							ss_ucsi_ccg_p0: endpoint {
+-								remote-endpoint = <&ss_typec_p0>;
+-							};
+-						};
+-					};
+-				};
+-
+-				ccg_typec_con1: connector@1 {
+-					compatible = "usb-c-connector";
+-					reg = <1>;
+-					label = "USB-C";
+-					data-role = "dual";
+-
+-					ports {
+-						#address-cells = <1>;
+-						#size-cells = <0>;
+-
+-						port@0 {
+-							reg = <0>;
+-
+-							hs_ucsi_ccg_p1: endpoint {
+-								remote-endpoint = <&hs_typec_p1>;
+-							};
+-						};
+-
+-						port@1 {
+-							reg = <1>;
+-
+-							ss_ucsi_ccg_p1: endpoint {
+-								remote-endpoint = <&ss_typec_p1>;
+-							};
+-						};
+-					};
+-				};
+-			};
+-		};
+ 
+ 		pcie@14100000 {
+ 			status = "okay";

--- a/meta-gig/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_%.bbappend
+++ b/meta-gig/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_%.bbappend
@@ -15,6 +15,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://0001-pcie-msi-distribution-devicetree.patch \
+    file://0002-USB-peripheral-mode-devicetree.patch \
     file://tegra234-p3701-0008-gr002007.dts \
 "
 

--- a/meta-gigcompute/conf/machine/gigcompute.conf
+++ b/meta-gigcompute/conf/machine/gigcompute.conf
@@ -11,6 +11,8 @@ ROOTFSPART_SIZE_DEFAULT ?= "59055800320"
 EMMC_BCT ?= "tegra234-p3701-0008-sdram-l4t.dts"
 PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_t234_qspi_sdmmc_industrial.xml"
 TEGRA_AUDIO_DEVICE ?= "tegra-ape"
+TNSPEC_BOOTDEV_DEFAULT = "mmcblk0p1"
+TNSPEC_BOOTDEV = "nvme0n1p1"
 
 # Needed to disable 10g PHY on built-in ethernet
 ODMDATA = "gbe-uphy-config-0,hsstp-lane-map-3,hsio-uphy-config-16,nvhs-uphy-config-0"

--- a/meta-gigrouter/conf/machine/gigrouter.conf
+++ b/meta-gigrouter/conf/machine/gigrouter.conf
@@ -11,6 +11,8 @@ ROOTFSPART_SIZE_DEFAULT ?= "59055800320"
 EMMC_BCT ?= "tegra234-p3701-0008-sdram-l4t.dts"
 PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_t234_qspi_sdmmc_industrial.xml"
 TEGRA_AUDIO_DEVICE ?= "tegra-ape"
+TNSPEC_BOOTDEV_DEFAULT = "mmcblk0p1"
+TNSPEC_BOOTDEV = "nvme0n1p1"
 
 # Needed to disable 10g PHY on built-in ethernet
 ODMDATA = "gbe-uphy-config-0,hsstp-lane-map-3,hsio-uphy-config-16,nvhs-uphy-config-0"


### PR DESCRIPTION
This changeset makes the requisite device tree changes to support flashing the Gig system storage drive over USB. initrd-flash performs the flashing by first loading a Linux kernel and init ramdisk containing tools for mounting and writing drives (this is in contrast to doflash.sh which writes the eMMC directly while remaining in recovery mode). Once operating an init script sets up the flashing USB port as a periperhal for the flashing host to send drive images.

The requisite changes were to set up the USB port as peripheral hardware. Other USB ports are explicitly disabled since they're not used in the hardware design. vbus-supply is assigned to a fixed regulator node which allows the port to be enabled.