### PR TITLE
Add 60W power profile to GigCompute build

### DIFF
--- a/meta-gigcompute/recipes-bsp/tegra-binaries/files/nvpmodel_p3701_gigcompute.conf
+++ b/meta-gigcompute/recipes-bsp/tegra-binaries/files/nvpmodel_p3701_gigcompute.conf
@@ -1,0 +1,297 @@
+#
+# Copyright (c) 2021-2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# NVIDIA CORPORATION and its licensors retain all intellectual property
+# and proprietary rights in and to this software, related documentation
+# and any modifications thereto.  Any use, reproduction, disclosure or
+# distribution of this software and related documentation without an express
+# license agreement from NVIDIA CORPORATION is strictly prohibited.
+#
+# FORMAT:
+# < PARAM TYPE=PARAM_TYPE NAME=PARAM_NAME >
+# ARG1_NAME ARG1_PATH_VAL
+# ARG2_NAME ARG2_PATH_VAL
+# ...
+# This starts a section of PARAM definitions, in which each line
+# has the syntax below:
+# ARG_NAME ARG_PATH_VAL
+# ARG_NAME is a macro name for argument value ARG_PATH_VAL.
+# PARAM_TYPE can be FILE, or CLOCK.
+#
+# < POWER_MODEL ID=id_num NAME=mode_name >
+# PARAM1_NAME ARG11_NAME ARG11_VAL
+# PARAM1_NAME ARG12_NAME ARG12_VAL
+# PARAM2_NAME ARG21_NAME ARG21_VAL
+# ...
+# This starts a section of POWER_MODEL configurations, followed by
+# lines with parameter settings as the format below:
+# PARAM_NAME ARG_NAME ARG_VAL
+# PARAM_NAME and ARG_NAME are defined in PARAM definition sections.
+# ARG_VAL is an integer for PARAM_TYPE of CLOCK, and -1 is taken
+# as INT_MAX. ARG_VAL is a string for PARAM_TYPE of FILE.
+# This file must contain at least one POWER_MODEL section.
+#
+# < PM_CONFIG DEFAULT=default_mode >
+# This is a mandatory section to specify one of the defined power
+# model as the default.
+
+###########################
+#                         #
+# PARAM DEFINITIONS       #
+#                         #
+###########################
+
+< PARAM TYPE=FILE NAME=CPU_ONLINE >
+CORE_0 /sys/devices/system/cpu/cpu0/online
+CORE_1 /sys/devices/system/cpu/cpu1/online
+CORE_2 /sys/devices/system/cpu/cpu2/online
+CORE_3 /sys/devices/system/cpu/cpu3/online
+CORE_4 /sys/devices/system/cpu/cpu4/online
+CORE_5 /sys/devices/system/cpu/cpu5/online
+CORE_6 /sys/devices/system/cpu/cpu6/online
+CORE_7 /sys/devices/system/cpu/cpu7/online
+CORE_8 /sys/devices/system/cpu/cpu8/online
+CORE_9 /sys/devices/system/cpu/cpu9/online
+CORE_10 /sys/devices/system/cpu/cpu10/online
+CORE_11 /sys/devices/system/cpu/cpu11/online
+
+< PARAM TYPE=FILE NAME=TPC_POWER_GATING >
+TPC_PG_MASK /sys/devices/gpu.0/tpc_pg_mask
+TPC_PG_MASK_KNEXT /sys/devices/platform/gpu.0/tpc_pg_mask
+
+< PARAM TYPE=FILE NAME=GPU_POWER_CONTROL_ENABLE >
+GPU_PWR_CNTL_EN /sys/devices/gpu.0/power/control
+GPU_PWR_CNTL_EN_KNEXT /sys/devices/platform/gpu.0/power/control
+
+< PARAM TYPE=FILE NAME=GPU_POWER_CONTROL_DISABLE >
+GPU_PWR_CNTL_DIS /sys/devices/gpu.0/power/control
+GPU_PWR_CNTL_DIS_KNEXT /sys/devices/platform/gpu.0/power/control
+
+< PARAM TYPE=CLOCK NAME=CPU_A78_0 >
+FREQ_TABLE /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_frequencies
+MAX_FREQ /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+MIN_FREQ /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
+FREQ_TABLE_KNEXT /sys/devices/system/cpu/cpu0/cpufreq/scaling_available_frequencies
+MAX_FREQ_KNEXT /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
+MIN_FREQ_KNEXT /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
+
+< PARAM TYPE=CLOCK NAME=CPU_A78_1 >
+FREQ_TABLE /sys/devices/system/cpu/cpu4/cpufreq/scaling_available_frequencies
+MAX_FREQ /sys/devices/system/cpu/cpu4/cpufreq/scaling_max_freq
+MIN_FREQ /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
+FREQ_TABLE_KNEXT /sys/devices/system/cpu/cpu4/cpufreq/scaling_available_frequencies
+MAX_FREQ_KNEXT /sys/devices/system/cpu/cpu4/cpufreq/scaling_max_freq
+MIN_FREQ_KNEXT /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq
+
+< PARAM TYPE=CLOCK NAME=CPU_A78_2 >
+FREQ_TABLE /sys/devices/system/cpu/cpu8/cpufreq/scaling_available_frequencies
+MAX_FREQ /sys/devices/system/cpu/cpu8/cpufreq/scaling_max_freq
+MIN_FREQ /sys/devices/system/cpu/cpu8/cpufreq/scaling_min_freq
+FREQ_TABLE_KNEXT /sys/devices/system/cpu/cpu8/cpufreq/scaling_available_frequencies
+MAX_FREQ_KNEXT /sys/devices/system/cpu/cpu8/cpufreq/scaling_max_freq
+MIN_FREQ_KNEXT /sys/devices/system/cpu/cpu8/cpufreq/scaling_min_freq
+
+< PARAM TYPE=CLOCK NAME=GPU >
+FREQ_TABLE /sys/devices/17000000.ga10b/devfreq/17000000.ga10b/available_frequencies
+MAX_FREQ /sys/devices/17000000.ga10b/devfreq/17000000.ga10b/max_freq
+MIN_FREQ /sys/devices/17000000.ga10b/devfreq/17000000.ga10b/min_freq
+FREQ_TABLE_KNEXT /sys/devices/platform/17000000.gpu/devfreq_dev/available_frequencies
+MAX_FREQ_KNEXT /sys/devices/platform/17000000.gpu/devfreq_dev/max_freq
+MIN_FREQ_KNEXT /sys/devices/platform/17000000.gpu/devfreq_dev/min_freq
+
+<PARAM TYPE=CLOCK NAME=EMC >
+MAX_FREQ /sys/kernel/nvpmodel_emc_cap/emc_iso_cap
+MAX_FREQ_KNEXT /sys/kernel/nvpmodel_clk_cap/emc
+
+< PARAM TYPE=CLOCK NAME=DLA0_CORE >
+MAX_FREQ /sys/devices/platform/13e40000.host1x/15880000.nvdla0/acm/clk_cap/dla0_core
+MAX_FREQ_KNEXT /sys/devices/platform/bus@0/13e00000.host1x/15880000.nvdla0/clk_cap/dla0_core
+
+< PARAM TYPE=CLOCK NAME=DLA0_FALCON >
+MAX_FREQ /sys/devices/platform/13e40000.host1x/15880000.nvdla0/acm/clk_cap/dla0_falcon
+MAX_FREQ_KNEXT /sys/devices/platform/bus@0/13e00000.host1x/15880000.nvdla0/clk_cap/dla0_falcon
+
+< PARAM TYPE=CLOCK NAME=DLA1_CORE >
+MAX_FREQ /sys/devices/platform/13e40000.host1x/158c0000.nvdla1/acm/clk_cap/dla1_core
+MAX_FREQ_KNEXT /sys/devices/platform/bus@0/13e00000.host1x/158c0000.nvdla1/clk_cap/dla1_core
+
+< PARAM TYPE=CLOCK NAME=DLA1_FALCON >
+MAX_FREQ /sys/devices/platform/13e40000.host1x/158c0000.nvdla1/acm/clk_cap/dla1_falcon
+MAX_FREQ_KNEXT /sys/devices/platform/bus@0/13e00000.host1x/158c0000.nvdla1/clk_cap/dla1_falcon
+
+< PARAM TYPE=CLOCK NAME=PVA0_VPS >
+MAX_FREQ /sys/devices/platform/13e40000.host1x/16000000.pva0/acm/clk_cap/pva0_vps
+MAX_FREQ_KNEXT /sys/devices/platform/bus@0/13e00000.host1x/16000000.pva0/clk_cap/pva0_vps
+
+< PARAM TYPE=CLOCK NAME=PVA0_AXI >
+MAX_FREQ /sys/devices/platform/13e40000.host1x/16000000.pva0/acm/clk_cap/pva0_cpu_axi
+MAX_FREQ_KNEXT /sys/devices/platform/bus@0/13e00000.host1x/16000000.pva0/clk_cap/pva0_cpu_axi
+
+###########################
+#                         #
+# POWER_MODEL DEFINITIONS #
+#                         #
+###########################
+
+# MAXN is the NONE power model to release all constraints
+< POWER_MODEL ID=0 NAME=MAXN >
+CPU_ONLINE CORE_0 1
+CPU_ONLINE CORE_1 1
+CPU_ONLINE CORE_2 1
+CPU_ONLINE CORE_3 1
+CPU_ONLINE CORE_4 1
+CPU_ONLINE CORE_5 1
+CPU_ONLINE CORE_6 1
+CPU_ONLINE CORE_7 1
+CPU_ONLINE CORE_8 1
+CPU_ONLINE CORE_9 1
+CPU_ONLINE CORE_10 1
+CPU_ONLINE CORE_11 1
+TPC_POWER_GATING TPC_PG_MASK 0
+GPU_POWER_CONTROL_ENABLE GPU_PWR_CNTL_EN on
+CPU_A78_0 MIN_FREQ 729600
+CPU_A78_0 MAX_FREQ -1
+CPU_A78_1 MIN_FREQ 729600
+CPU_A78_1 MAX_FREQ -1
+CPU_A78_2 MIN_FREQ 729600
+CPU_A78_2 MAX_FREQ -1
+GPU MIN_FREQ 0
+GPU MAX_FREQ -1
+GPU_POWER_CONTROL_DISABLE GPU_PWR_CNTL_DIS auto
+EMC MAX_FREQ -1
+DLA0_CORE MAX_FREQ -1
+DLA1_CORE MAX_FREQ -1
+DLA0_FALCON MAX_FREQ -1
+DLA1_FALCON MAX_FREQ -1
+PVA0_VPS MAX_FREQ -1
+PVA0_AXI MAX_FREQ -1
+
+< POWER_MODEL ID=1 NAME=MODE_15W >
+CPU_ONLINE CORE_0 1
+CPU_ONLINE CORE_1 1
+CPU_ONLINE CORE_2 1
+CPU_ONLINE CORE_3 1
+CPU_ONLINE CORE_4 0
+CPU_ONLINE CORE_5 0
+CPU_ONLINE CORE_6 0
+CPU_ONLINE CORE_7 0
+CPU_ONLINE CORE_8 0
+CPU_ONLINE CORE_9 0
+CPU_ONLINE CORE_10 0
+CPU_ONLINE CORE_11 0
+TPC_POWER_GATING TPC_PG_MASK 248
+GPU_POWER_CONTROL_ENABLE GPU_PWR_CNTL_EN on
+CPU_A78_0 MIN_FREQ 729600
+CPU_A78_0 MAX_FREQ 1113600
+GPU MIN_FREQ 0
+GPU MAX_FREQ 408000000
+GPU_POWER_CONTROL_DISABLE GPU_PWR_CNTL_DIS auto
+EMC MAX_FREQ 2133000000
+DLA0_CORE MAX_FREQ 614400000
+DLA1_CORE MAX_FREQ 614400000
+DLA0_FALCON MAX_FREQ 294400000
+DLA1_FALCON MAX_FREQ 294400000
+PVA0_VPS MAX_FREQ 307200000
+PVA0_AXI MAX_FREQ 217600000
+
+< POWER_MODEL ID=2 NAME=MODE_30W >
+CPU_ONLINE CORE_0 1
+CPU_ONLINE CORE_1 1
+CPU_ONLINE CORE_2 1
+CPU_ONLINE CORE_3 1
+CPU_ONLINE CORE_4 1
+CPU_ONLINE CORE_5 1
+CPU_ONLINE CORE_6 1
+CPU_ONLINE CORE_7 1
+CPU_ONLINE CORE_8 0
+CPU_ONLINE CORE_9 0
+CPU_ONLINE CORE_10 0
+CPU_ONLINE CORE_11 0
+TPC_POWER_GATING TPC_PG_MASK 240
+GPU_POWER_CONTROL_ENABLE GPU_PWR_CNTL_EN on
+CPU_A78_0 MIN_FREQ 729600
+CPU_A78_0 MAX_FREQ 1728000
+CPU_A78_1 MIN_FREQ 729600
+CPU_A78_1 MAX_FREQ 1728000
+GPU MIN_FREQ 0
+GPU MAX_FREQ 612000000
+GPU_POWER_CONTROL_DISABLE GPU_PWR_CNTL_DIS auto
+EMC MAX_FREQ -1
+DLA0_CORE MAX_FREQ 1369600000
+DLA1_CORE MAX_FREQ 1369600000
+DLA0_FALCON MAX_FREQ 729600000
+DLA1_FALCON MAX_FREQ 729600000
+PVA0_VPS MAX_FREQ 512000000
+PVA0_AXI MAX_FREQ 358400000
+
+< POWER_MODEL ID=3 NAME=MODE_50W >
+CPU_ONLINE CORE_0 1
+CPU_ONLINE CORE_1 1
+CPU_ONLINE CORE_2 1
+CPU_ONLINE CORE_3 1
+CPU_ONLINE CORE_4 1
+CPU_ONLINE CORE_5 1
+CPU_ONLINE CORE_6 1
+CPU_ONLINE CORE_7 1
+CPU_ONLINE CORE_8 1
+CPU_ONLINE CORE_9 1
+CPU_ONLINE CORE_10 1
+CPU_ONLINE CORE_11 1
+TPC_POWER_GATING TPC_PG_MASK 0
+GPU_POWER_CONTROL_ENABLE GPU_PWR_CNTL_EN on
+CPU_A78_0 MIN_FREQ 729600
+CPU_A78_0 MAX_FREQ 1497600
+CPU_A78_1 MIN_FREQ 729600
+CPU_A78_1 MAX_FREQ 1497600
+CPU_A78_2 MIN_FREQ 729600
+CPU_A78_2 MAX_FREQ 1497600
+GPU MIN_FREQ 0
+GPU MAX_FREQ 816000000
+GPU_POWER_CONTROL_DISABLE GPU_PWR_CNTL_DIS auto
+EMC MAX_FREQ -1
+DLA0_CORE MAX_FREQ 1369600000
+DLA1_CORE MAX_FREQ 1369600000
+DLA0_FALCON MAX_FREQ 729600000
+DLA1_FALCON MAX_FREQ 729600000
+PVA0_VPS MAX_FREQ 704000000
+PVA0_AXI MAX_FREQ 486400000
+
+# Custom model for GR/GC to keep system power usage under 60W
+# The goal is to create a model where benchmarks top at 55W, with 5W margin before a potential hard max of 60W
+# Summary of differences between this and the stock 60W model:
+# - TCP_POWER_GATING TPC_PG_MASK set to 120
+# - GPU MAX_FREQ set to 700000000
+< POWER_MODEL ID=4 NAME=GC_60W >
+CPU_ONLINE CORE_0 1
+CPU_ONLINE CORE_1 1
+CPU_ONLINE CORE_2 1
+CPU_ONLINE CORE_3 1
+CPU_ONLINE CORE_4 1
+CPU_ONLINE CORE_5 1
+CPU_ONLINE CORE_6 1
+CPU_ONLINE CORE_7 1
+CPU_ONLINE CORE_8 1
+CPU_ONLINE CORE_9 1
+CPU_ONLINE CORE_10 1
+CPU_ONLINE CORE_11 1
+TPC_POWER_GATING TPC_PG_MASK 120
+GPU_POWER_CONTROL_ENABLE GPU_PWR_CNTL_EN on
+CPU_A78_0 MIN_FREQ 729600
+CPU_A78_0 MAX_FREQ 1497600
+CPU_A78_1 MIN_FREQ 729600
+CPU_A78_1 MAX_FREQ 1497600
+CPU_A78_2 MIN_FREQ 729600
+CPU_A78_2 MAX_FREQ 1497600
+GPU MIN_FREQ 0
+GPU MAX_FREQ 700000000
+GPU_POWER_CONTROL_DISABLE GPU_PWR_CNTL_DIS auto
+EMC MAX_FREQ 0
+DLA0_CORE MAX_FREQ 1382400000
+DLA1_CORE MAX_FREQ 1382400000
+DLA0_FALCON MAX_FREQ 742400000
+DLA1_FALCON MAX_FREQ 742400000
+PVA0_VPS MAX_FREQ 704000000
+PVA0_AXI MAX_FREQ 486400000
+
+# mandatory section to configure the default power mode
+< PM_CONFIG DEFAULT=4 >

--- a/meta-gigcompute/recipes-bsp/tegra-binaries/tegra-nvpmodel-base_%.bbappend
+++ b/meta-gigcompute/recipes-bsp/tegra-binaries/tegra-nvpmodel-base_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI += " \
+    file://nvpmodel_p3701_gigcompute.conf \
+"
+
+do_install:append() {
+    install -m 0440 ${WORKDIR}/nvpmodel_p3701_gigcompute.conf ${D}${sysconfdir}/nvpmodel.conf
+}
+
+FILES:${PN} += "${sysconfdir}/nvpmodel.conf"


### PR DESCRIPTION
This changeset adds a custom power profile which constrains draw to <~60W. The profile is set to be used as the default but is only supported for the GigCompute platform, GigRouter is unaffected.