### PR TITLE
Resolve malformed output on ttyTHS UART.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **[nvidia-kernel-oot]** - Update DTS overlay to resolve malformed output on secondary serial port (ttyTHS1).
+
+### Added
+
+- **[wireguard]** - Wireguard VPN utilities.
+- **[chrony]** - chrony utility and service.
+
 ## [2026.05.04] 2.1.3
 
 ### Added

--- a/meta-gig/recipes-kernel/nvidia-kernel-oot/files/tegra234-p3701-0008-gr002007.dts
+++ b/meta-gig/recipes-kernel/nvidia-kernel-oot/files/tegra234-p3701-0008-gr002007.dts
@@ -3,6 +3,7 @@
 
 #include <dt-bindings/gpio/tegra234-gpio.h>
 #include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/memory/tegra234-mc.h>
 
 / {
 	fragment@0 {
@@ -104,6 +105,16 @@
 			       <&p2u_gbe_4>, <&p2u_gbe_5>, <&p2u_gbe_6>, <&p2u_gbe_7>;
 			phy-names = "p2u-0", "p2u-1", "p2u-2", "p2u-3", 
 				    "p2u-4", "p2u-5", "p2u-6", "p2u-7";
+		};
+	};
+
+	// Resolve DMA issue on the THS (Tegra High-Speed) UART
+	// introduced in JetPack 6.2.2. May be removed in future releases:
+	// https://forums.developer.nvidia.com/t/dma-on-dev-ttyths1-corrupts-receiving-data/369191
+	fragment@4 {
+		target-path = "/bus@0/serial@3100000";
+		__overlay__ {
+			iommus = <&smmu_niso0 TEGRA234_SID_GPCDMA>;
 		};
 	};
 };


### PR DESCRIPTION
This changeset resolves a DMA issue introduced in JetPack 6.2.2 where output from the Tegra High-Speed (THS) UART is malformed. The updated overlay may be removed with future JetPack releases which address the problem.

Ticket information: https://forums.developer.nvidia.com/t/dma-on-dev-ttyths1-corrupts-receiving-data/369191