### PR TITLE
Apply Gen 2 speeds to PCIe interface.

### DIFF
--- a/meta-gig/recipes-kernel/nvidia-kernel-oot/files/tegra234-p3701-0008-gr002007.dts
+++ b/meta-gig/recipes-kernel/nvidia-kernel-oot/files/tegra234-p3701-0008-gr002007.dts
@@ -117,4 +117,13 @@
 			iommus = <&smmu_niso0 TEGRA234_SID_GPCDMA>;
 		};
 	};
+
+	// Set PCIe interface to Gen2
+	fragment@5 {
+		target-path = "/bus@0/pcie@141a0000";
+		__overlay__ {
+			max-link-speed = <2>;
+			nvidia,max-speed = <2>;
+		};
+	};
 };


### PR DESCRIPTION
Set this PCIe interface to Gen2 speeds since lab testing has found it to be more stable.